### PR TITLE
External tracking, project directory fix and process group destroy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
 torch>=1.13.0
-accelerate>=0.19.0
+accelerate>=0.34.2
 numpy>=1.22.0
 tqdm>=4.65.0
 tensorboard>=2.12.0
 flake8>=6.0.0
 termcolor>=2.0.0
-adict @ git+https://github.com/dsenushkin/adict.git
-
-
+adict@git+https://github.com/dsenushkin/adict.git

--- a/rocket/core/checkpoint.py
+++ b/rocket/core/checkpoint.py
@@ -71,6 +71,15 @@ class Checkpointer(Capsule):
         self._overwrite = overwrite
         self._iter_idx = 0
 
+    def setup(self, attrs: Attributes | None = None) -> None:
+        if self._accelerator.project_dir is None:
+            raise ValueError(
+                'Checkpointer can be used only when project directory is configured'
+                'Current project directory is None. '
+                'This might be due to the `tag=None` set when creating `rocket.Launcher`. '
+                'Set `tag` parameter of `rocket.Launcher` to a specific experiment name'
+            )
+
     def launch(self, attrs: Attributes | None = None) -> None:
         """
         Handles the :code:`Events.LAUNCH` event.

--- a/rocket/core/launcher.py
+++ b/rocket/core/launcher.py
@@ -274,8 +274,7 @@ class Launcher(Dispatcher):
 
     @staticmethod
     def destroy_process_group():
-        if dist.is_initialized():
-            dist.destroy_process_group()
+        PartialState().destroy_process_group()
 
     def destroy(self, attrs: Attributes | None = None) -> None:
         """

--- a/rocket/core/tracker.py
+++ b/rocket/core/tracker.py
@@ -83,7 +83,10 @@ class Tracker(Capsule):
         None
         """
         Capsule.setup(self, attrs=attrs)
-        self._tracker = self._accelerator.get_tracker(self._backend)
+        if isinstance(self._backend, GeneralTracker):
+            self._tracker = self._backend
+        else:
+            self._tracker = self._accelerator.get_tracker(self._backend)
 
         if type(self._tracker) == GeneralTracker:   # noqa E721
             self._logger.warn(

--- a/rocket/core/tracker.py
+++ b/rocket/core/tracker.py
@@ -95,7 +95,6 @@ class Tracker(Capsule):
                 )
 
                 try:
-                    project_name = os.path.basename(self._accelerator.project_dir)
                     self._accelerator.log_with.append(self._backend)
                     self._accelerator.init_trackers('', self._config)
                 except Exception as e:

--- a/rocket/core/tracker.py
+++ b/rocket/core/tracker.py
@@ -88,22 +88,22 @@ class Tracker(Capsule):
         else:
             self._tracker = self._accelerator.get_tracker(self._backend)
 
-        if type(self._tracker) == GeneralTracker:   # noqa E721
-            self._logger.warn(
-                f"Accelerator has not initialized {self._backend}. "
-                "Trying to create it..."
-            )
-
-            try:
-                project_name = os.path.basename(self._accelerator.project_dir)
-                self._accelerator.log_with.append(self._backend)
-                self._accelerator.init_trackers('', self._config)
-            except Exception as e:
-                raise RuntimeError(
-                    f"{self.__class__.__name__} can't create tracker: {e}"
+            if type(self._tracker) == GeneralTracker:   # noqa E721
+                self._logger.warn(
+                    f"Accelerator has not initialized {self._backend}. "
+                    "Trying to create it..."
                 )
 
-        self._tracker = self._accelerator.get_tracker(self._backend)
+                try:
+                    project_name = os.path.basename(self._accelerator.project_dir)
+                    self._accelerator.log_with.append(self._backend)
+                    self._accelerator.init_trackers('', self._config)
+                except Exception as e:
+                    raise RuntimeError(
+                        f"{self.__class__.__name__} can't create tracker: {e}"
+                    )
+
+            self._tracker = self._accelerator.get_tracker(self._backend)
 
     def set(self, attrs: Attributes | None = None) -> None:
         """


### PR DESCRIPTION
* Added ability to use external tracker, like GeneralTracker
* Option to destroy process group after launch is finished
* Fixed bug when multiple project directories could be created when versioning is enabled. Also added ability to not create project directory when not needed by setting `tag=None` in Launcher